### PR TITLE
Cleanup: Drop gcs-references

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -39,7 +39,8 @@ sinker:
 deck:
   spyglass:
     size_limit: 100000000 # 100MB
-    gcs_browser_prefix: https://console.cloud.google.com/storage/browser/
+    #s3_browser_prefix is not supported
+    #gcs_browser_prefix: https://console.cloud.google.com/storage/browser/
     lenses:
     - lens:
         name: metadata


### PR DESCRIPTION
s3_browser_prefix is not supported
Using this PR to test logs in s3 bucket. DO_NOT_MERGE for some time

Signed-off-by: Rajas Kakodkar <rkakodkar@vmware.com>