### PR TITLE
Add s3-credentials to deck

### DIFF
--- a/config/prow/components.yaml
+++ b/config/prow/components.yaml
@@ -201,6 +201,7 @@ spec:
         - --github-endpoint=http://ghproxy
         - --github-endpoint=https://api.github.com
         - --github-graphql-endpoint=http://ghproxy/graphql
+        - --s3-credentials-file=/etc/s3-credentials/s3-credentials.json
         - --spyglass=true
         - --github-app-id=$(GITHUB_APP_ID)
         - --github-app-private-key-path=/etc/github/cert


### PR DESCRIPTION
Fix to get around the issue
```
error rendering spyglass page: error when resolving real path s3/tanzu-prow-logs/pr-logs/pull/rajaskakodkar_tanzu-test-infra/51/pull-test-infra-prow-checkconfig/1508874476001955840: blob (key "pr-logs/pull/rajaskakodkar_tanzu-test-infra/51/pull-test-infra-prow-checkconfig/1508874476001955840.txt") (code=Unknown): MissingRegion: could not find region configuration
```

Signed-off-by: Rajas Kakodkar <rkakodkar@vmware.com>