### PR TITLE
Replace s3-credentials.json with service-account.json

### DIFF
--- a/config/prow/components.yaml
+++ b/config/prow/components.yaml
@@ -201,7 +201,7 @@ spec:
         - --github-endpoint=http://ghproxy
         - --github-endpoint=https://api.github.com
         - --github-graphql-endpoint=http://ghproxy/graphql
-        - --s3-credentials-file=/etc/s3-credentials/s3-credentials.json
+        - --s3-credentials-file=/etc/s3-credentials/service-account.json
         - --spyglass=true
         - --github-app-id=$(GITHUB_APP_ID)
         - --github-app-private-key-path=/etc/github/cert
@@ -372,7 +372,7 @@ spec:
         - --github-endpoint=http://ghproxy
         - --github-endpoint=https://api.github.com
         - --github-graphql-endpoint=http://ghproxy/graphql
-        - --s3-credentials-file=/etc/s3-credentials/s3-credentials.json
+        - --s3-credentials-file=/etc/s3-credentials/service-account.json
         - --status-path=s3://tanzu-prow-logs/tide-status
         - --history-uri=s3://tanzu-prow-logs/tide-history.json
         - --github-app-id=$(GITHUB_APP_ID)
@@ -500,7 +500,7 @@ spec:
         - --config-path=/etc/config/config.yaml
         - --github-endpoint=http://ghproxy
         - --github-endpoint=https://api.github.com
-        - --s3-credentials-file=/etc/s3-credentials/s3-credentials.json
+        - --s3-credentials-file=/etc/s3-credentials/service-account.json
         - --status-path=s3://tanzu-prow-logs/status-reconciler-status
         - --github-app-id=$(GITHUB_APP_ID)
         - --github-app-private-key-path=/etc/github/cert
@@ -1118,7 +1118,7 @@ spec:
         args:
         - --blob-storage-workers=10
         - --config-path=/etc/config/config.yaml
-        - --s3-credentials-file=/etc/s3-credentials/s3-credentials.json
+        - --s3-credentials-file=/etc/s3-credentials/service-account.json
         - --github-endpoint=http://ghproxy
         - --github-endpoint=https://api.github.com
         - --github-workers=10


### PR DESCRIPTION
initupload expects the credential secret to be named as `service-account.json` and not anything else. 

This fixes the following issue

```
Init container initupload not ready: (state: terminated, reason: "Error", message: "{\"component\":\"initupload\",\"error\":\"failed to upload to blob storage: new opener: open /secrets/s3-storage/service-account.json: no such file or directory\",\"file\":\"prow/gcsupload/run.go:59\",\"func\":\"k8s.io/test-infra/prow/gcsupload.Options.Run\",\"level\":\"info\",\"msg\":\"Also failed to upload extra targets\",\"severity\":\"info\",\"time\":\"2022-03-29T18:31:24Z\"}\n{\"component\":\"initupload\",\"error\":\"failed to upload to blob storage: failed to upload to blob storage: new opener: open /secrets/s3-storage/service-account.json: no such file or directory\",\"file\":\"prow/cmd/initupload/main.go:45\",\"func\":\"main.main\",\"level\":\"fatal\",\"msg\":\"Failed to initialize job\",\"severity\":\"fatal\",\"time\":\"2022-03-29T18:31:24Z\"}\n") Init container place-entrypoint not ready: (state: waiting, reason: "PodInitializing", message: "")
```


Signed-off-by: Rajas Kakodkar <rkakodkar@vmware.com>