### PR TITLE
Experimental: Add S3 console URL to gcs_browser_prefix

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -39,7 +39,7 @@ sinker:
 deck:
   spyglass:
     size_limit: 100000000 # 100MB
-    gcs_browser_prefix: https://console.cloud.google.com/storage/browser/
+    gcs_browser_prefix: https://s3.console.aws.amazon.com/s3/buckets/
     lenses:
     - lens:
         name: metadata


### PR DESCRIPTION
Following up on the migration to s3 bucket for prow job logs, the URL pointed by `Artifacts` in spyglass should have URL prefix to console to view logs. Replaced the gcs console prefix with s3 to see if it works

Signed-off-by: Rajas Kakodkar <rkakodkar@vmware.com>