### PR TITLE
Reflect changes in Testgrid config post s3 migration and prow.tanzu.io migration

### DIFF
--- a/config/jobs/build-images/build.yaml
+++ b/config/jobs/build-images/build.yaml
@@ -1,64 +1,58 @@
-postsubmits:
-  rajaskakodkar/tanzu-test-infra:
-  - name: build-test-image
-    decorate: true
-    run_if_changed: "images/test/.*"
-    branches:
-    - ^main$
-    annotations:
-      testgrid-dashboards: build-images
-      testgrid-tab-name: Building test images
-    spec:
-      containers:
-      - name: docker-build
-        image: docker:20.10.12-dind
-        command:
-        - ./scripts/ci-docker-build-image.sh
-        args:
-        - ./images/dind-go-kubectl
-        securityContext:
-          privileged: true
-        env:
-        - name: DOCKER_TLS_CERTDIR
-          value: ""
-        - name: DOCKER_HOST
-          value: tcp://localhost:2375
-        volumeMounts:
-        - name: dind-storage
-          mountPath: /var/lib/docker
-      volumes:
-      - name: dind-storage
-        emptyDir: {}
-
-periodics:
-- name: periodic-build-test-image
-  decorate: true
-  interval: 24h
-  extra_refs:
-  - org: rajaskakodkar
-    repo: prow-test-infra
-    base_ref: main
-  annotations:
-    testgrid-dashboards: build-images
-    testgrid-tab-name: periodics
-  spec:
-    containers:
-    - name: docker-build
-      image: docker:20.10.12-dind
-      command:
-      - ./scripts/ci-docker-build-image.sh
-      args:
-      - ./images/dind-go-kubectl
-      securityContext:
-        privileged: true
-      env:
-      - name: DOCKER_TLS_CERTDIR
-        value: ""
-      - name: DOCKER_HOST
-        value: tcp://localhost:2375
-      volumeMounts:
-      - name: dind-storage
-        mountPath: /var/lib/docker
-    volumes:
-    - name: dind-storage
-      emptyDir: {}
+#postsubmits:
+#  rajaskakodkar/tanzu-test-infra:
+#  - name: build-test-image
+#    decorate: true
+#    run_if_changed: "images/test/.*"
+#    branches:
+#    - ^main$
+#    spec:
+#      containers:
+#      - name: docker-build
+#        image: docker:20.10.12-dind
+#        command:
+#        - ./scripts/ci-docker-build-image.sh
+#        args:
+#        - ./images/dind-go-kubectl
+#        securityContext:
+#          privileged: true
+#        env:
+#        - name: DOCKER_TLS_CERTDIR
+#          value: ""
+#        - name: DOCKER_HOST
+#          value: tcp://localhost:2375
+#        volumeMounts:
+#        - name: dind-storage
+#          mountPath: /var/lib/docker
+#      volumes:
+#      - name: dind-storage
+#        emptyDir: {}
+#
+#periodics:
+#- name: periodic-build-test-image
+#  decorate: true
+#  interval: 24h
+#  extra_refs:
+#  - org: rajaskakodkar
+#    repo: prow-test-infra
+#    base_ref: main
+#  spec:
+#    containers:
+#    - name: docker-build
+#      image: docker:20.10.12-dind
+#      command:
+#      - ./scripts/ci-docker-build-image.sh
+#      args:
+#      - ./images/dind-go-kubectl
+#      securityContext:
+#        privileged: true
+#      env:
+#      - name: DOCKER_TLS_CERTDIR
+#        value: ""
+#      - name: DOCKER_HOST
+#        value: tcp://localhost:2375
+#      volumeMounts:
+#      - name: dind-storage
+#        mountPath: /var/lib/docker
+#    volumes:
+#    - name: dind-storage
+#      emptyDir: {}

--- a/config/jobs/tanzu-test-infra/postsubmits.yaml
+++ b/config/jobs/tanzu-test-infra/postsubmits.yaml
@@ -8,8 +8,8 @@ postsubmits:
     - ^main$
     run_if_changed: '^images/image-build*'
     annotations:
-      testgrid-dashboards: build-images
-      testgrid-tab-name: image-builder
+      testgrid-dashboards: testing-images
+      testgrid-tab-name: post-image-builder
     labels:
       preset-registry-credentials: "true"
       preset-dind-enabled: "true"
@@ -32,8 +32,8 @@ postsubmits:
     - ^main$
     run_if_changed: '^images/test-image*'
     annotations:
-      testgrid-dashboards: build-images
-      testgrid-tab-name: test-image
+      testgrid-dashboards: testing-images
+      testgrid-tab-name: post-test-image
     labels:
       preset-registry-credentials: "true"
       preset-dind-enabled: "true"

--- a/config/jobs/tce/periodics.yaml
+++ b/config/jobs/tce/periodics.yaml
@@ -1,28 +1,4 @@
 periodics:
-- name: periodic-build-tce
-  decorate: true
-  interval: 24h
-  extra_refs:
-  - org: rajaskakodkar
-    repo: tanzu-test-infra
-    base_ref: main
-  annotations:
-    testgrid-dashboards: tce
-    testgrid-tab-name: periodics
-  labels:
-    preset-dind-enabled: "true"
-  spec:
-    containers:
-    - image: public.ecr.aws/t0q8k6g2/vagator/test-image:v20222903-be6db42
-      command:
-      - /usr/local/bin/run.sh
-      args:
-      - vmware-tanzu
-      - community-edition
-      - make docker-management-and-cluster-e2e-test
-      securityContext:
-        privileged: true
-
 # - name: periodic-test-tce-job-aws
 #   cluster: test-jobs
 #   decorate: true
@@ -32,9 +8,6 @@ periodics:
 #   - org: rajaskakodkar
 #     repo: tanzu-test-infra
 #     base_ref: main
-#   annotations:
-#     testgrid-dashboards: tce
-#     testgrid-tab-name: periodics
 #   labels:
 #     preset-aws-credential: "true"
 #     preset-kind-volume-mounts: "true"
@@ -84,14 +57,14 @@ periodics:
   cluster: test-jobs
   decorate: true
   interval:  24h
-  #cron: 0/15 * * * * 
+  #cron: 0/15 * * * *
   extra_refs:
   - org: rajaskakodkar
     repo: tanzu-test-infra
     base_ref: main
   annotations:
-    testgrid-dashboards: tce
-    testgrid-tab-name: periodics
+    testgrid-dashboards: CAPD
+    testgrid-tab-name: nightly
   labels:
     preset-aws-credential: "true"
     preset-kind-volume-mounts: "true"

--- a/config/testgrid/config.yaml
+++ b/config/testgrid/config.yaml
@@ -1,30 +1,12 @@
 dashboard_groups:
-- name: vagator
+- name: tanzu-test-infra
   dashboard_names:
-    - test-prow
-    - build-images
+    - testing-images
+- name: tce
+  dashboard_names:
+    - CAPD
 
 dashboards:
-- name: test-prow
-  dashboard_tab:
-    - name: Vagator Testing Prow
-      test_group_name: test-prow-group
-- name: build-images
-  dashboard_tab:
-    - name: Vagator Building test images
-      test_group_name: build-images-group
-    - name: vagator-periodics
-      test_group_name: periodic-building-test-images-group
-    - name: image-builder
-      test_group_name: push-image-builder
+- name: testing-images
+- name: CAPD
 
-test_groups:
-- name: test-prow-group
-  gcs_prefix: vagator-prow/logs/test-postsubmit
-- name: build-images-group
-  gcs_prefix: vagator-prow/logs/build-test-image
-- name: periodic-building-test-images-group
-  gcs_prefix: vagator-prow/logs/periodic-build-test-image
-- name: push-image-builder
-  gcs_prefix: vagator-prow/logs/push-image-builder
-  

--- a/config/testgrid/default.yaml
+++ b/config/testgrid/default.yaml
@@ -12,9 +12,9 @@ default_test_group:
   num_passes_to_disable_alert: 1 # Consider a failing test passing if it has 1 or more consecutive passes
 default_dashboard_tab:
   open_test_template:            # The URL template to visit after clicking on a cell
-    url: https://prow.rajaskakodkar.dev/view/gcs/<gcs_prefix>/<changelist>
+    url: https://prow.tanzu.io/view/s3/<gcs_prefix>/<changelist>
   file_bug_template:             # The URL template to visit when filing a bug
-    url: https://github.com/rajaskakodkar/prow-on-tce/issues/new
+    url: https://github.com/rajaskakodkar/tanzu-test-infra/issues/new
     options:
     - key: title
       value: "Test \"<test-name>\" failed"
@@ -26,11 +26,12 @@ default_dashboard_tab:
   # Text to show in the about menu as a link to another view of the results
   results_text: See these results on Prow
   results_url_template:          # The URL template to visit after clicking
-    url: https://prow.rajaskakodkar.dev/job-history/<gcs_prefix>
+    url: https://prow.tanzu.io/job-history/s3/<gcs_prefix>
   # URL for regression search links.
-  code_search_path: github.com/rajaskakodkar/prow-on-tce/search
+  code_search_path: github.com/rajaskakodkar/tanzu-test-infra/search
   num_columns_recent: 10
   code_search_url_template:      # The URL template to visit when searching for changelists
-    url: https://github.com/rajaskakodkar/prow-on-tce/compare/<start-custom-0>...<end-custom-0>
+    url: https://github.com/rajaskakodkar/tanzu-test-infra/compare/<start-custom-0>...<end-custom-0>
   num_failures_to_alert: 0
   num_passes_to_disable_alert: 1
+


### PR DESCRIPTION
This is a follow-up on migration of prow logs to S3.

Front end of testgrid could be generated with the changes in this PR.

However, testgrid backend has updater controller which checks for Prow job logs and populates cells in testgrid. This controller currently accepts only GCS buckets for source of truth of Prow job logs and does not work with S3. 

```
{"config":"gs://vagator-testgrid/config","error":"read first column: group path: gs://bucket may not contain a port: gs://s3:/tanzu-prow-logs/logs/post-test-image/","file":"pkg/updater/updater.go:378","func":"github.com/GoogleCloudPlatform/testgrid/pkg/updater.Update.func
2","group":"post-test-image","level":"error","msg":"Failed to update group","time":"2022-03-31T09:17:04Z"}
```

This PR should be merged only when updater supports S3.

Signed-off-by: Rajas Kakodkar <rkakodkar@vmware.com>